### PR TITLE
Add reference to Grunt task in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,6 @@ Here are some suggested guidelines to follow when writing your code:
 
 Writing documentation is _hard_; hopefully citare helps to streamline the process for you!
 
+## Grunt task
+
+A Grunt plugin is available [here](https://github.com/naganowl/grunt-citare-scriptum).


### PR DESCRIPTION
Really more of a heads up, no need to accept if you don't want to.

Love the improvements made to `groc` (especially no dependencies on `pygments`/`python`).
